### PR TITLE
Let signals get the HttpRequest and return an HttpResponse

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -138,6 +138,23 @@ you can do something like:
 
         do_stuff()
 
+You shoud expect that the ``post_email_confirm`` signal may be sent more than once if the user clicks on the confirmation link more than once (possibly by accident). This is by design so that the correct HttpResponse can be given in those cases (see next paragraph).
+
+The ``post_email_confirm`` signal handler will also recieve the HttpRequest object as a keyword argument (which allows you to set messages, for instance) and can return an HttpResponse to override the default behavior of showing a simple success page. For example:
+
+.. code-block:: python
+
+    from django.contrib import messages
+    from django.http import HttpResponseRedirect
+
+    @receiver(post_email_confirm)
+    def post_email_confirm_callback(sender, confirmation, request=None, **kwargs):
+        ...
+        messages.add_message(request, messages.SUCCESS, 'You are confirmed.')
+        return HttpResponseRedirect(model_instace.get_absolute_url())
+
+If multiple handlers are registered to receive the signal, the first to return a value besides None will determine the response sent to the user. 
+
 Commands
 ========
 

--- a/email_confirm_la/models.py
+++ b/email_confirm_la/models.py
@@ -176,23 +176,39 @@ class EmailConfirmation(models.Model):
             confirmation=self,
         )
 
-    def confirm(self):
-        if self.is_expired():
-            raise EmailConfirmationExpired()
+    def confirm(self, request):
+        if not self.is_verified:
+            if self.is_expired():
+                raise EmailConfirmationExpired()
+            with transaction.atomic():
+                self.is_verified = True
+                self.confirmed_at = timezone.now()
+                # self.save(update_fields=['is_verified', 'confirmed_at'])
+                update_fields(self, fields=('is_verified', 'confirmed_at'))
+
+                signal_responses = signals.post_email_confirm.send(
+                    sender=self.__class__,
+                    confirmation=self,
+                    request=request,
+                )
+
+                if self.is_primary and settings.EMAIL_CONFIRM_LA_SAVE_EMAIL_TO_INSTANCE:
+                    self.save_email()
+
         else:
-            if not self.is_verified:
-                with transaction.atomic():
-                    self.is_verified = True
-                    self.confirmed_at = timezone.now()
-                    # self.save(update_fields=['is_verified', 'confirmed_at'])
-                    update_fields(self, fields=('is_verified', 'confirmed_at'))
+            # This email confirmation is already verified, but the user may
+            # click the link twice (by accident?). The response should still
+            # be helpful. Re-issue the signal.
+            signal_responses = signals.post_email_confirm.send(
+                sender=self.__class__,
+                confirmation=self,
+                request=request,
+            )
 
-                    signals.post_email_confirm.send(
-                        sender=self.__class__,
-                        confirmation=self,
-                    )
+        # signal.send() returns a list of tuples of the receiver and the
+        # returned value from that receiver.
+        for reciver, response in signal_responses:
+            if response is not None:
+                return response
 
-                    if self.is_primary and settings.EMAIL_CONFIRM_LA_SAVE_EMAIL_TO_INSTANCE:
-                        self.save_email()
-
-        return self
+        return None

--- a/email_confirm_la/signals.py
+++ b/email_confirm_la/signals.py
@@ -6,5 +6,5 @@ import django.dispatch
 
 
 post_email_confirmation_send = django.dispatch.Signal(providing_args=['confirmation', ])
-post_email_confirm = django.dispatch.Signal(providing_args=['confirmation', ])
+post_email_confirm = django.dispatch.Signal(providing_args=['confirmation', 'request'])
 post_email_save = django.dispatch.Signal(providing_args=['confirmation', ])

--- a/email_confirm_la/views.py
+++ b/email_confirm_la/views.py
@@ -2,7 +2,7 @@
 
 from __future__ import unicode_literals
 
-from django.http import Http404
+from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import render
 
 from email_confirm_la.models import EmailConfirmation
@@ -15,7 +15,9 @@ def confirm_email(request, confirmation_key):
         # TODO: show a email confirm fail page
         raise Http404
 
-    email_confirmation.confirm()
+    response = email_confirmation.confirm(request)
+    if response:
+        return response
 
     context = {
         'email_confirmation': email_confirmation,


### PR DESCRIPTION
It's convenient to have the confirmation redirect to some other page besides a dedicated success page. If I'm confirming an action, I usually take the user to a page that shows the action. Showing a success message is often put into an alert.

This PR makes that possible by passing the HttpRequest into the post_confirm signal and treating return values  (if not None) as HttpResponses.

It's also convenient to allow the user to click the email confirmation more than once but have the same output shown to the user. The user might accidentally click the link twice in their email client. The verification may happen in the first request but the user should still get a helpful response in the second request.

There are other ways these use cases might be handled besides adding request/response logic to the signal handler. Happy to talk about alternative implementations. A redirect to the content_object's get_absolute_url might also do the trick (but would be less flexible).