### PR TITLE
My _meta.object_name fix was wrong

### DIFF
--- a/email_confirm_la/admin.py
+++ b/email_confirm_la/admin.py
@@ -9,11 +9,7 @@ from email_confirm_la.models import EmailConfirmation
 
 
 class EmailConfirmationAdmin(admin.ModelAdmin):
-    def show_content_type(self, obj):
-        return ContentType.objects.get_for_model(obj).name
-    show_content_type.short_description = 'Content type'
-
-    list_display = ('show_content_type', 'content_object', 'email_field_name', 'email', 'is_verified', 'is_primary', 'send_at', 'confirmed_at')
+    list_display = ('content_type', 'content_object', 'email_field_name', 'email', 'is_verified', 'is_primary', 'send_at', 'confirmed_at')
     list_display_links = list_display
     search_fields = ('email', )
     ordering = ('-id', )


### PR DESCRIPTION
The admin now shows the content type of EmailConfirmation --- oops. This re-does that fix.
