### PR TITLE
Allow two different users to claim the same email

### DIFF
--- a/email_confirm_la/migrations/0002_alter_unique_together.py
+++ b/email_confirm_la/migrations/0002_alter_unique_together.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('email_confirm_la', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='emailconfirmation',
+            unique_together=set([('content_type', 'email_field_name', 'object_id', 'email', )]),
+        ),
+    ]

--- a/email_confirm_la/models.py
+++ b/email_confirm_la/models.py
@@ -92,7 +92,7 @@ class EmailConfirmation(models.Model):
     class Meta:
         verbose_name = _('ec_la', 'Email confirmation')
         verbose_name_plural = _('ec_la', 'Email confirmation')
-        unique_together = (('content_type', 'email_field_name', 'email'), )
+        unique_together = (('content_type', 'email_field_name', 'object_id', 'email'), )
 
     def __unicode__(self):
         return 'Confirmation for %s' % self.email

--- a/email_confirm_la/models.py
+++ b/email_confirm_la/models.py
@@ -200,4 +200,11 @@ class EmailConfirmation(models.Model):
                     if self.is_primary and settings.EMAIL_CONFIRM_LA_SAVE_EMAIL_TO_INSTANCE:
                         self.save_email()
 
+                    # Expire all other confirmations for the same email
+                    reverse_expiry = timezone.now() - datetime.timedelta(seconds=settings.EMAIL_CONFIRM_LA_CONFIRM_EXPIRE_SEC)
+                    EmailConfirmation.objects.filter(
+                        content_type=self.content_type,
+                        email_field_name=self.email_field_name,
+                        email=self.email).exclude(pk=self.pk).update(send_at=reverse_expiry)
+
         return self

--- a/email_confirm_la/tests/test_models.py
+++ b/email_confirm_la/tests/test_models.py
@@ -26,6 +26,8 @@ class ManagerTest(BaseTestCase):
         self.your_obj = YourModel.objects.create()
         self.your_customer_support_email = 'marvin@therestaurantattheendoftheuniverse.com'
         self.your_marketing_email = 'arthur@therestaurantattheendoftheuniverse.com'
+        
+        self.user2_obj = User.objects.create_user(username='odyx')
 
     def test_set_email_for_object_with_user_model(self):
         confirmation = EmailConfirmation.objects.set_email_for_object(
@@ -104,6 +106,18 @@ class ManagerTest(BaseTestCase):
         self.assertTrue(confirmation.is_verified)
         self.assertEqual(len(mail.outbox), 0)
         self.assertEqual(self.user_obj.email, self.user_email)
+
+    def test_request_email_by_two_users(self):
+        confirmation1 = EmailConfirmation.objects.set_email_for_object(
+            email=self.user_email,
+            content_object=self.user_obj,
+        )
+        confirmation2 = EmailConfirmation.objects.set_email_for_object(
+            email=self.user_email,
+            content_object=self.user2_obj,
+        )
+        self.assertTrue(confirmation1.email, self.user_email)
+        self.assertTrue(confirmation2.email, self.user_email)
 
 
 class ModelTest(BaseTestCase):


### PR DESCRIPTION
Let the latter create a new EmailConfirmation object, through relaxing of the unique_together requirements,

The problem with the cu
The second request for the same email creates a new EmailConfirmation object, through relaxing of the unique_together requirements

The problem with the previous behaviour was that two different users
could not request the same email; an IntegrityError exception would be raised.
