### PR TITLE
Two updates (using Site for domain as doc says, specifying template context)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,13 +111,15 @@ And you want to verify some emails:
     EmailConfirmation.objects.verify_email_for_object(
         email='marvin@therestaurantattheendoftheuniverse.com',
         content_object=some_model_instance,
-        email_field_name='customer_support_email'
+        email_field_name='customer_support_email',
+        template_context={'this_is_for': 'customer support'}
     )
 
     EmailConfirmation.objects.verify_email_for_object(
         email='arthur.dent@therestaurantattheendoftheuniverse.com',
         content_object=some_model_instance,
-        email_field_name='marketing_email'
+        email_field_name='marketing_email',
+        tempalte_context={'this_is_for': 'marketing'}
     )
 
 Signals

--- a/email_confirm_la/conf.py
+++ b/email_confirm_la/conf.py
@@ -1,12 +1,17 @@
 # coding: utf-8
 
 from django.conf import settings
+from django.contrib.sites.models import Site
+from django.core.exceptions import ImproperlyConfigured
 
 
 class DefaultConfigs(object):
 
     EMAIL_CONFIRM_LA_HTTP_PROTOCOL = 'http'
-    EMAIL_CONFIRM_LA_DOMAIN = 'example.com'
+    try:
+        EMAIL_CONFIRM_LA_DOMAIN = Site.objects.get_current().domain
+    except ImproperlyConfigured:
+        EMAIL_CONFIRM_LA_DOMAIN = 'example.com'
     EMAIL_CONFIRM_LA_CONFIRM_EXPIRE_SEC = 60 * 60 * 24 * 1  # 1 day
     EMAIL_CONFIRM_LA_CONFIRM_URL_REVERSE_NAME = 'email_confirm_la:confirm_email'
     EMAIL_CONFIRM_LA_TEMPLATE_CONTEXT = {}

--- a/email_confirm_la/models.py
+++ b/email_confirm_la/models.py
@@ -21,7 +21,7 @@ from email_confirm_la.utils import generate_random_token
 
 class EmailConfirmationManager(models.Manager):
 
-    def verify_email_for_object(self, email, content_object, email_field_name='email'):
+    def verify_email_for_object(self, email, content_object, email_field_name='email', template_context=None):
         """
         Create an email confirmation for `content_object` and send a confirmation mail.
 
@@ -43,7 +43,7 @@ class EmailConfirmationManager(models.Manager):
             confirmation.confirmation_key = confirmation_key
             confirmation.save(update_fields=['email', 'confirmation_key'])
 
-        confirmation.send()
+        confirmation.send(template_context=template_context)
 
         return confirmation
 

--- a/email_confirm_la/tests/test_views.py
+++ b/email_confirm_la/tests/test_views.py
@@ -102,6 +102,17 @@ class ViewTest(BaseTestCase):
 
         self.assertContains(response, 'the Answer to the Ultimate Question of Life, the Universe, and Everything: 42.')
 
+    def test_user_added_template_context_in_email(self):
+        EmailConfirmation.objects.verify_email_for_object(
+            email=self.user_email,
+            content_object=self.user_obj,
+            template_context={'THE_ANSWER': 'has been changed'}
+        )
+
+        mail_obj = mail.outbox[0]
+
+        self.assertIn('the Answer to the Ultimate Question of Life, the Universe, and Everything: has been changed.', mail_obj.body)
+
     @override_settings(EMAIL_CONFIRM_LA_AUTOLOGIN=True)
     def test_autologin(self):
         confirmation = EmailConfirmation.objects.verify_email_for_object(

--- a/test_project/test_project/settings.py
+++ b/test_project/test_project/settings.py
@@ -36,6 +36,7 @@ INSTALLED_APPS = [
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
+    'django.contrib.sites',
     'django.contrib.staticfiles',
     'test_app',
     'email_confirm_la',


### PR DESCRIPTION
1. The README says that if EMAIL_CONFIRM_LA_DOMAIN isn't set, Site.objects.get_current().domain will be used. Code didn't actually do that. EMAIL_CONFIRM_LA_DOMAIN was hardcoded to 'example.com'. Updated to actually use Site.objects.get_current().domain as the default value. If there is an exception (Site isn't being used), will fallback to 'example.com'.

2. Added ability to send in template context data when using verify_email_for_object(). This function was calling send() which already had the ability to accept template context data (but was never used since verify_email_for_object() never passed any context data through).

Updated README and added unit tests as well.